### PR TITLE
feat: add configuration options for wrap and filetype

### DIFF
--- a/rplugin/python3/plugin.py
+++ b/rplugin/python3/plugin.py
@@ -42,6 +42,9 @@ class TestPlugin(object):
             # Create a new scratch buffer to hold the chat
             self.nvim.command("enew")
             self.nvim.command("setlocal buftype=nofile bufhidden=hide noswapfile")
+            # Set filetype as markdown and wrap
+            self.nvim.command("setlocal filetype=markdown")
+            self.nvim.command("setlocal wrap")
         if self.nvim.current.line != "":
             self.nvim.command("normal o")
         for token in self.copilot.ask(prompt, code, language=file_type):


### PR DESCRIPTION
# What
- Set filetype to markdown and text wrapping.

# Why
- This change improves the user experience: we provide a more organized and readable chat environment