### PR TITLE
Improved Text Retrieval & Split-Screen Window

### DIFF
--- a/rplugin/python3/plugin.py
+++ b/rplugin/python3/plugin.py
@@ -45,7 +45,7 @@ class CopilotChatPlugin(object):
             prompt = prompts.EXPLAIN_SHORTCUT
 
         # Get code from the unnamed register
-        code = text = self.nvim.current.buffer[:]
+        code = self.nvim.current.buffer[:]
         file_type = self.nvim.eval("expand('%')").split(".")[-1]
         # Check if we're already in a chat buffer
         if self.nvim.eval("getbufvar(bufnr(), '&buftype')") != "nofile":

--- a/rplugin/python3/plugin.py
+++ b/rplugin/python3/plugin.py
@@ -45,7 +45,7 @@ class CopilotChatPlugin(object):
             prompt = prompts.EXPLAIN_SHORTCUT
 
         # Get code from the unnamed register
-        code = self.nvim.eval("getreg('\"')")
+        code = text = self.nvim.current.buffer[:]
         file_type = self.nvim.eval("expand('%')").split(".")[-1]
         # Check if we're already in a chat buffer
         if self.nvim.eval("getbufvar(bufnr(), '&buftype')") != "nofile":

--- a/rplugin/python3/plugin.py
+++ b/rplugin/python3/plugin.py
@@ -50,7 +50,11 @@ class CopilotChatPlugin(object):
         # Check if we're already in a chat buffer
         if self.nvim.eval("getbufvar(bufnr(), '&buftype')") != "nofile":
             # Create a new scratch buffer to hold the chat
-            self.nvim.command("enew")
+            self.nvim.command("vnew")
+            # Set it to the left side of the screen
+            self.nvim.command("wincmd L")
+            self.nvim.command("vertical resize 50%")
+            # Set the buffer type to nofile and hide it when it's not active
             self.nvim.command("setlocal buftype=nofile bufhidden=hide noswapfile")
             # Set filetype as markdown and wrap with linebreaks
             self.nvim.command("setlocal filetype=markdown wrap linebreak")


### PR DESCRIPTION
## Changes Made
- Modified the window opening behavior to split-screen.
- Replaced nvim.current.eval("getreg('\"')") with nvim.current.buffer[:] for retrieving the code.
> [!TIP]
>nvim.current.eval("getreg('\"')") :
> It only contains the text from the most recent yank, delete, change, or put operation, if there were no changes it didn't give any output
**Before**
![Screenshot 2024-01-02 151549](https://github.com/gptlang/CopilotChat.nvim/assets/78022236/6764c901-599b-40aa-9041-085be9e7850e)
**After**
![Screenshot 2024-01-02 151714](https://github.com/gptlang/CopilotChat.nvim/assets/78022236/8a53808a-e0a4-4f64-a3a5-9cdb0f5edca0)

